### PR TITLE
Add installation via conda in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,14 @@ If you get permission errors, try using ``sudo``::
     $ sudo pip install nextflow
 
 
+Miniconda
+~~~
+
+The package is available via [Bioconda](https://anaconda.org/bioconda/python-nextflow)::
+
+    $ conda install -c bioconda python-nextflow
+
+
 Development
 ~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,10 @@ If you get permission errors, try using ``sudo``::
 
 
 Miniconda
-~~~
+~~~~~~~~~
 
-The package is available via [Bioconda](https://anaconda.org/bioconda/python-nextflow)::
+
+The package is available via `Bioconda <https://anaconda.org/bioconda/python-nextflow>`::
 
     $ conda install -c bioconda python-nextflow
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Miniconda
 ~~~~~~~~~
 
 
-The package is available via `Bioconda <https://anaconda.org/bioconda/python-nextflow>`::
+The package is available via `Bioconda <https://anaconda.org/bioconda/python-nextflow>`_::
 
     $ conda install -c bioconda python-nextflow
 


### PR DESCRIPTION
I added a recipe for nextflow.py in bioconda (as `python-nextflow`).

When a new GitHub release is available, a bot will make a PR to add the new version to bioconda as well. 

(ATM requires Python>3.6 <3.9, which is too restrictive and I will relax it after some more tests)