### PR TITLE
refactor(models.Execution): add none as a type option for `started` a…

### DIFF
--- a/nextflow/models.py
+++ b/nextflow/models.py
@@ -27,8 +27,8 @@ class Execution:
     stdout: str
     stderr: str
     return_code: str
-    started: datetime
-    finished: datetime
+    started: datetime | None
+    finished: datetime | None
     command: str
     log: str
     path: str
@@ -74,8 +74,8 @@ class ProcessExecution:
     return_code: str
     bash: str
     submitted: datetime
-    started: datetime
-    finished: datetime
+    started: datetime | None
+    finished: datetime | None
     status: str
     cached: bool
     io: Any


### PR DESCRIPTION
…nd `finished` fields

These were previously only typed as `datetime`. This caught me out, as I got a runtime error where they were None. Adding the type hint should hopefully help others avoiding the same mistake.