### PR TITLE
fix(ProcessExecution): pass io parameter through input_data to get_fi…

### DIFF
--- a/nextflow/models.py
+++ b/nextflow/models.py
@@ -105,15 +105,15 @@ class ProcessExecution:
         return Path(self.execution.path, "work", self.path)
 
 
-    def input_data(self, include_path=True):
+    def input_data(self, include_path=True, io=None):
         """A list of files passed to the process execution as inputs.
 
         :param bool include_path: if ``False``, only filenames returned.
+        :param io: an optional custom io object to handle file operations.
         :type: ``list``"""
 
-        inputs = []
         if not self.path: return []
-        run = get_file_text(self.full_path / ".command.run")
+        run = get_file_text(self.full_path / ".command.run", io=io)
         stage = re.search(r"nxf_stage\(\)((.|\n|\r)+?)}", run)
         if not stage: return []
         contents = stage[1]
@@ -135,7 +135,7 @@ class ProcessExecution:
 
         outputs = []
         if not self.path: return []
-        inputs = self.input_data(include_path=False)
+        inputs = self.input_data(include_path=False, io=io)
         listdir = io.listdir if io else os.listdir
         for f in listdir(self.full_path):
             full_path = Path(f"{self.full_path}/{f}")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as f:
 
 setup(
     name="nextflowpy",
-    version="0.12.1",
+    version="0.13.0",
     description="A Python wrapper around Nextflow.",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/tests/unit/test_process_executions.py
+++ b/tests/unit/test_process_executions.py
@@ -107,8 +107,8 @@ class InputDataTests(ProcessExecutionTest):
             self.process_execution.input_data(),
             ["/work/25/7eaa7786ca/file1.dat", "/work/fe/3b80569ba5/file2.dat"]
         )
-        mock_text.assert_called_with(Path("/loc/.command.run"))
-    
+        mock_text.assert_called_with(Path("/loc/.command.run"), io=None)
+
 
     @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
     @patch("nextflow.models.get_file_text")
@@ -119,8 +119,8 @@ class InputDataTests(ProcessExecutionTest):
             self.process_execution.input_data(include_path=False),
             ["file1.dat", "file2.dat"]
         )
-        mock_text.assert_called_with(Path("/loc/.command.run"))
-    
+        mock_text.assert_called_with(Path("/loc/.command.run"), io=None)
+
 
     @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
     @patch("nextflow.models.get_file_text")
@@ -130,8 +130,8 @@ class InputDataTests(ProcessExecutionTest):
         self.assertEqual(
             self.process_execution.input_data(include_path=False), []
         )
-        mock_text.assert_called_with(Path("/loc/.command.run"))
-    
+        mock_text.assert_called_with(Path("/loc/.command.run"), io=None)
+
 
     @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
     @patch("nextflow.models.get_file_text")
@@ -141,7 +141,7 @@ class InputDataTests(ProcessExecutionTest):
         self.assertEqual(
             self.process_execution.input_data(include_path=False), []
         )
-        mock_text.assert_called_with(Path("/loc/.command.run"))
+        mock_text.assert_called_with(Path("/loc/.command.run"), io=None)
     
 
     @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
@@ -178,7 +178,19 @@ class InputDataTests(ProcessExecutionTest):
             self.process_execution.input_data(),
             ["/work/25/7eaa7786ca/file1.dat", "/work/fe/3b80569ba5/file2.dat"]
         )
-        mock_text.assert_called_with(Path("/loc/.command.run"))
+        mock_text.assert_called_with(Path("/loc/.command.run"), io=None)
+
+
+    @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
+    def test_can_get_input_data_with_custom_io(self, mock_path):
+        mock_path.return_value = Path("/loc")
+        io = Mock()
+        io.read.return_value = self.text
+        self.assertEqual(
+            self.process_execution.input_data(io=io),
+            ["/work/25/7eaa7786ca/file1.dat", "/work/fe/3b80569ba5/file2.dat"]
+        )
+        io.read.assert_called_with(Path("/loc/.command.run"))
 
 
 
@@ -195,9 +207,9 @@ class AllOutputDataTests(ProcessExecutionTest):
             self.make_process_execution().all_output_data(),
             [str(Path("/loc/file1")), str(Path("/loc/file3"))]
         )
-        mock_input.assert_called_with(include_path=False)
+        mock_input.assert_called_with(include_path=False, io=None)
         mock_dir.assert_called_with(mock_path.return_value)
-    
+
 
     @patch("nextflow.models.ProcessExecution.input_data")
     @patch("nextflow.models.ProcessExecution.full_path", new_callable=PropertyMock)
@@ -210,7 +222,7 @@ class AllOutputDataTests(ProcessExecutionTest):
             self.make_process_execution().all_output_data(include_path=False),
             ["file1", "file3"]
         )
-        mock_input.assert_called_with(include_path=False)
+        mock_input.assert_called_with(include_path=False, io=None)
         mock_dir.assert_called_with(mock_path.return_value)
 
 
@@ -239,4 +251,4 @@ class AllOutputDataTests(ProcessExecutionTest):
             self.make_process_execution().all_output_data(io=io),
             [str(Path("/loc/file1")), str(Path("/loc/file3"))]
         )
-        mock_input.assert_called_with(include_path=False)
+        mock_input.assert_called_with(include_path=False, io=io)


### PR DESCRIPTION
…le_text

input_data() always read from the local filesystem because it didn't accept or forward an io parameter, unlike all_output_data() which did. This meant that when using a remote filesystem (e.g. SSH), input_data() would fail to read .command.run files. Now input_data() accepts io and passes it to get_file_text(), and all_output_data() forwards its io through to input_data().

Bumps version to 0.13.0.